### PR TITLE
New JSON URL to get Client IP Address

### DIFF
--- a/src/geo.js
+++ b/src/geo.js
@@ -174,7 +174,8 @@ Geo.IPProvider.Base = Class.extend({
 	}
 });
 Geo.IPProvider.JSONIP = Geo.IPProvider.Base.extend({
-	url: 'http://jsonip.appspot.com/'
+	url: 'http://jsonip.com/'
+	//url: 'http://jsonip.appspot.com/'
 });
 
 // =============================================================================


### PR DESCRIPTION
The URL http://jsonip.appspot.com has changed to http://jsonip.com. The method getIPAddress() didn't work with the old address. 
